### PR TITLE
Add support for widget push updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,41 @@ Sending a message is as simple as:
     success <- sendMessage session token None payload
     print success
 
+## Widget Support
+
+push-notify-apn supports WidgetKit push notifications for updating iOS widgets. Widget notifications use a different push type and topic format.
+
+### Sending Widget Notifications
+
+For convenience, use the `sendWidgetNotification` function:
+
+    success <- sendWidgetNotification session token Nothing
+    print success
+
+This sends a widget update notification with the `content-changed` flag set to `true`, which will cause WidgetKit to reload your widget's timeline.
+
+### Manual Widget Message Construction
+
+You can also construct widget messages manually:
+
+    let widgetMessage = newWidgetMessage
+    success <- sendMessage session token Nothing widgetMessage
+    print success
+
+### Topic Configuration
+
+When sending widget notifications, the library automatically appends `.push-type.widgets` to your bundle identifier. So if your session was created with bundle ID `com.example.MyApp`, widget notifications will be sent to topic `com.example.MyApp.push-type.widgets`.
+
+### Requirements
+
+To use widget notifications, ensure your iOS app:
+
+1. Has the Push Notifications capability enabled for the widget extension target
+2. Implements a `WidgetPushHandler` to handle push token updates
+3. Configures the widget with `.pushHandler()` in your `WidgetConfiguration`
+
+For more details, see Apple's documentation on WidgetKit push notifications.
+
 # command line utility
 
 The command line utility can be used for testing your app. Use like this:

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+0.5.0.0
+=======
+
+- Add WidgetKit push notification support
+- Add ApnPushType enum for specifying push type (currently supports alert, background, and widgets)
+- Add newWidgetMessage function for creating widget notifications with content-changed flag
+- Add sendWidgetNotification convenience function
+- Update all send functions to support push type headers
+
 0.4.0.3
 =======
 

--- a/push-notify-apn.cabal
+++ b/push-notify-apn.cabal
@@ -1,5 +1,5 @@
 name:                push-notify-apn
-version:             0.4.0.3
+version:             0.5.0.0
 synopsis:            Send push notifications to mobile iOS devices
 description:
     push-notify-apn is a library and command line utility that can be used to send

--- a/test/Network/PushNotify/APNSpec.hs
+++ b/test/Network/PushNotify/APNSpec.hs
@@ -18,6 +18,7 @@ spec = do
             "badge"    .= Null,
             "mutable-content" .= Null,
             "interruption-level" .= Null,
+            "content-changed" .= Null,
             "alert"    .= object [
               "title" .= String "hello",
               "body"  .= String "world"
@@ -31,6 +32,7 @@ spec = do
             "badge"    .= Null,
             "mutable-content" .= Null,
             "interruption-level" .= Null,
+            "content-changed" .= Null,
             "alert"    .= object [
               "title" .= String "hello",
               "subtitle" .= String "there",
@@ -45,6 +47,7 @@ spec = do
             "badge"    .= Null,
             "mutable-content" .= Null,
             "interruption-level" .= Null,
+            "content-changed" .= Null,
             "alert"    .= object [ "body"  .= String "hello world" ]
           ]
 
@@ -80,5 +83,51 @@ spec = do
     context "JSON decoder" $
       it "decodes the error correctly" $
         eitherDecode "\"TooManyProviderTokenUpdates\"" `shouldBe` Right ApnTemporaryErrorTooManyProviderTokenUpdates
+
+  describe "Widget notifications" $
+    context "JSON encoder" $ do
+      it "encodes widget message with content-changed flag" $
+        let (JsonAps widgetMsg _ _) = newWidgetMessage
+        in toJSON widgetMsg `shouldBe`
+          object [
+            "category" .= Null,
+            "sound"    .= Null,
+            "badge"    .= Null,
+            "mutable-content" .= Null,
+            "interruption-level" .= Null,
+            "content-changed" .= Bool True,
+            "alert"    .= Null
+          ]
+      
+      it "encodes complete widget message" $
+        toJSON newWidgetMessage `shouldBe` object [
+          "aps" .= object [
+            "category" .= Null,
+            "sound"    .= Null,
+            "badge"    .= Null,
+            "mutable-content" .= Null,
+            "interruption-level" .= Null,
+            "content-changed" .= Bool True,
+            "alert"    .= Null
+          ],
+          "appspecificcontent" .= Null,
+          "data" .= object []
+        ]
+
+  describe "ApnPushType" $ do
+    context "JSON encoder" $ do
+      it "encodes alert push type" $
+        toJSON ApnPushTypeAlert `shouldBe` String "alert"
+      it "encodes background push type" $
+        toJSON ApnPushTypeBackground `shouldBe` String "background"
+      it "encodes widgets push type" $
+        toJSON ApnPushTypeWidgets `shouldBe` String "widgets"
+    context "JSON decoder" $ do
+      it "decodes alert push type" $
+        eitherDecode "\"alert\"" `shouldBe` Right ApnPushTypeAlert
+      it "decodes background push type" $
+        eitherDecode "\"background\"" `shouldBe` Right ApnPushTypeBackground
+      it "decodes widgets push type" $
+        eitherDecode "\"widgets\"" `shouldBe` Right ApnPushTypeWidgets
   where
     (&) = flip ($)


### PR DESCRIPTION
Implements support for widget push updates, introduced in iOS 26, which are outlined [here](https://developer.apple.com/documentation/widgetkit/updating-widgets-with-widgetkit-push-notifications).